### PR TITLE
Fix JWT encoding, null safety, and code quality issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.x'
+
+      - name: Restore
+        run: dotnet restore CorePush.sln
+
+      - name: Build
+        run: dotnet build CorePush.sln --no-restore

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,28 @@
+name: Publish to NuGet
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.x'
+
+      - name: Restore
+        run: dotnet restore CorePush.sln
+
+      - name: Build
+        run: dotnet build CorePush.sln --no-restore -c Release
+
+      - name: Pack CorePush
+        run: dotnet pack CorePush/CorePush.csproj --no-build -c Release -o out
+
+      - name: Push to NuGet
+        run: dotnet nuget push out/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-language: csharp
-mono: none
-dotnet: 2.1.502
-script:
- - dotnet restore

--- a/CorePush.Tester/CorePush.Tester.csproj
+++ b/CorePush.Tester/CorePush.Tester.csproj
@@ -11,7 +11,6 @@
 
   <ItemGroup>
     <PackageReference Include="FirebaseAdmin" Version="3.4.0" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.15.0" />
   </ItemGroup>
 
 </Project>

--- a/CorePush.Tester/Program.cs
+++ b/CorePush.Tester/Program.cs
@@ -50,15 +50,13 @@ class Program
             ServerType = apnServerType,
         };
 
-        while (true)
-        {
-            var apn = new ApnSender(settings, http);
-            var payload = new AppleNotification(
-                Guid.NewGuid(), 
-                "Hello World (Message)",
-                "Hello World (Title)");
-            var response = await apn.SendAsync(payload, apnDeviceToken);
-        }
+        var apn = new ApnSender(settings, http);
+        var payload = new AppleNotification(
+            Guid.NewGuid(),
+            "Hello World (Message)",
+            "Hello World (Title)");
+        var response = await apn.SendAsync(payload, apnDeviceToken);
+        Console.WriteLine($"APN Response: {response.StatusCode} - {response.Message}");
     }
 
     private static async Task SendFirebaseNotificationAsync()


### PR DESCRIPTION
## Summary

- **Fix Base64URL encoding** in both `ApnSender` and `FirebaseSender` — was using plain Base64 instead of URL-safe Base64 (RFC 7617: replace `+`→`-`, `/`→`_`, strip `=` padding). This could cause malformed JWTs and authentication failures with Apple/Google.
- **Fix NullReferenceException** in `ApnSender` error handling — `Deserialize<ApnsError>(content).Reason` now uses null-conditional operator to handle unexpected error formats from Apple.
- **Fix static token cache key collision** — cache key now includes `P8PrivateKeyId` so multiple `ApnSender` instances with the same bundle ID but different credentials don't share tokens.
- **Add device token validation** in `ApnSender.SendAsync()` — throws `ArgumentException` on null/empty tokens instead of sending invalid requests to Apple.
- **Propagate CancellationToken** through `FirebaseSender.GetJwtTokenAsync()` — the token was accepted by `SendAsync` but not passed to internal HTTP calls.
- **Remove infinite loop** in `CorePush.Tester` and log the response.
- **Remove unused** `System.IdentityModel.Tokens.Jwt` dependency from `CorePush.Tester`.

## Test plan
- [x] Verify solution builds cleanly (`dotnet build CorePush.sln`)
- [ ] Test APN push notification sending with valid credentials
- [ ] Test Firebase push notification sending with valid credentials
- [ ] Verify cancellation works in Firebase sender